### PR TITLE
Automatically add success/failure stages

### DIFF
--- a/lib/cyclid/job/job.rb
+++ b/lib/cyclid/job/job.rb
@@ -95,7 +95,8 @@ module Cyclid
           # stages because we created on as an ad-hoc stage, or we need to load
           # it from the database, create a JobStage from it, and add it to the
           # list of stages
-          job[:sequence].each do |job_stage|
+          job_sequence = job[:sequence]
+          job_sequence.each do |job_stage|
             job_stage.symbolize_keys!
 
             raise ArgumentError, 'invalid stage definition' \
@@ -125,8 +126,17 @@ module Cyclid
               stage_view = StageView.new(stage)
             end
 
-            # Merge in the options specified in this job stage
+            # Merge in the options specified in this job stage. If the
+            # on_success or on_failure stages are not already in the sequence,
+            # append them to the end.
+            job_sequence << { stage: job_stage[:on_success] } \
+              unless job_stage[:on_success].nil? or\
+                     job_sequence.include? job_stage[:on_success]
             stage_view.on_success = job_stage[:on_success]
+
+            job_sequence << { stage: job_stage[:on_failure] } \
+              unless job_stage[:on_failure].nil? or \
+                     job_sequence.include? job_stage[:on_failure]
             stage_view.on_failure = job_stage[:on_failure]
 
             # Store the modified StageView

--- a/spec/job/runner_spec.rb
+++ b/spec/job/runner_spec.rb
@@ -101,6 +101,29 @@ describe Cyclid::API::Job::Runner do
     expect{ job.run }.to_not raise_error
   end
 
+  # Issue #5
+  it 'runs a job with a defined sequence that has success & failure handlers' do
+    stages = [{ name: 'test', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] },
+              { name: 'success', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] },
+              { name: 'failure', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] }]
+    sequence = [{ stage: 'test', 'on_success': 'success', 'on_failure': 'failure' }]
+    job_def = { name: 'test',
+                environment: {},
+                sources: [],
+                stages: stages,
+                sequence: sequence }
+
+    job_view = nil
+    expect{ job_view = Cyclid::API::Job::JobView.new(job_def, {}, @org) }.to_not raise_error
+
+    job_json = nil
+    expect{ job_json = job_view.to_hash.to_json }.to_not raise_error
+
+    job = nil
+    expect{ job = Cyclid::API::Job::Runner.new(3, job_json, @notifier) }.to_not raise_error
+    expect{ job.run }.to_not raise_error
+  end
+
   it 'checks out sources' do
     sources = [{ type: 'test', data: 'test' }]
     stages = [{ name: 'test', steps: [{ 'action' => 'command', 'cmd' => '/bin/true' }] }]


### PR DESCRIPTION
If the on_success or on_failure handler for a stage is not already in the
sequence, append it to the end of the list so that it gets loaded and added to
the final sequence automatically.
Fixes issue #5